### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kosmtik-mbtiles-export",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Export your Kosmtik project in MBTiles",
   "main": "index.js",
   "scripts": {
@@ -23,6 +23,6 @@
   "homepage": "https://github.com/kosmtik/kosmtik-mbtiles-export",
   "kosmtik": "~0.0.8",
   "dependencies": {
-    "mbtiles": "^0.7.3"
+    "mbtiles": "^0.8.2"
   }
 }


### PR DESCRIPTION
When I test with latest Node version (5.5), it fails for compiling when installing through Kosmtik.

To debug, I tried outside with `npm install kosmtik-mbtiles-export` and I got the same issue.

```
> sqlite3@3.0.10 install /kosmtik/node_modules/sqlite3
> node-pre-gyp install --fallback-to-build

make: Entering directory `/kosmtik/node_modules/sqlite3/build'
  ACTION deps_sqlite3_gyp_action_before_build_target_unpack_sqlite_dep Release/obj/gen/sqlite-autoconf-3081101/sqlite3.c
  TOUCH Release/obj.target/deps/action_before_build.stamp
  CC(target) Release/obj.target/sqlite3/gen/sqlite-autoconf-3081101/sqlite3.o
  AR(target) Release/obj.target/deps/sqlite3.a
  COPY Release/sqlite3.a
  CXX(target) Release/obj.target/node_sqlite3/src/database.o
In file included from ../src/database.h:11:0,
                 from ../src/database.cc:5:
../node_modules/nan/nan.h:261:25: error: redefinition of 'template<class T> v8::Local<T> _NanEnsureLocal(v8::Local<T>)'
 NAN_INLINE v8::Local<T> _NanEnsureLocal(v8::Local<T> val) {
                         ^
../node_modules/nan/nan.h:256:25: error: 'template<class T> v8::Local<T> _NanEnsureLocal(v8::Handle<T>)' previously declared here
 NAN_INLINE v8::Local<T> _NanEnsureLocal(v8::Handle<T> val) {
                         ^
../node_modules/nan/nan.h:661:13: error: 'node::smalloc' has not been declared
     , node::smalloc::FreeCallback callback
             ^
../node_modules/nan/nan.h:661:35: error: expected ',' or '...' before 'callback'
     , node::smalloc::FreeCallback callback
                                   ^
../node_modules/nan/nan.h: In function 'v8::Local<v8::Object> NanNewBufferHandle(char*, size_t, int)':
../node_modules/nan/nan.h:665:50: error: 'callback' was not declared in this scope
         v8::Isolate::GetCurrent(), data, length, callback, hint);
                                                  ^
../node_modules/nan/nan.h:665:60: error: 'hint' was not declared in this scope
         v8::Isolate::GetCurrent(), data, length, callback, hint);
                                                            ^
../node_modules/nan/nan.h: In function 'v8::Local<v8::Object> NanNewBufferHandle(const char*, uint32_t)':
../node_modules/nan/nan.h:672:67: error: call of overloaded 'New(v8::Isolate*, const char*&, uint32_t&)' is ambiguous
     return node::Buffer::New(v8::Isolate::GetCurrent(), data, size);
                                                                   ^
../node_modules/nan/nan.h:672:67: note: candidates are:
In file included from ../node_modules/nan/nan.h:25:0,
                 from ../src/database.h:11,
                 from ../src/database.cc:5:
/root/.node-gyp/5.5.0/include/node/node_buffer.h:31:40: note: v8::MaybeLocal<v8::Object> node::Buffer::New(v8::Isolate*, v8::Local<v8::String>, node::encoding) <near match>
 NODE_EXTERN v8::MaybeLocal<v8::Object> New(v8::Isolate* isolate,
                                        ^
/root/.node-gyp/5.5.0/include/node/node_buffer.h:31:40: note:   no known conversion for argument 3 from 'uint32_t {aka unsigned int}' to 'node::encoding'
/root/.node-gyp/5.5.0/include/node/node_buffer.h:43:40: note: v8::MaybeLocal<v8::Object> node::Buffer::New(v8::Isolate*, char*, size_t) <near match>
 NODE_EXTERN v8::MaybeLocal<v8::Object> New(v8::Isolate* isolate,
                                        ^
/root/.node-gyp/5.5.0/include/node/node_buffer.h:43:40: note:   no known conversion for argument 2 from 'const char*' to 'char*'
In file included from ../src/database.h:11:0,
                 from ../src/database.cc:5:
../node_modules/nan/nan.h: In function 'v8::Local<v8::Object> NanNewBufferHandle(uint32_t)':
../node_modules/nan/nan.h:676:61: error: could not convert 'node::Buffer::New(v8::Isolate::GetCurrent(), ((size_t)size))' from 'v8::MaybeLocal<v8::Object>' to 'v8::Local<v8::Object>'
     return node::Buffer::New(v8::Isolate::GetCurrent(), size);
                                                             ^
../node_modules/nan/nan.h: In function 'v8::Local<v8::Object> NanBufferUse(char*, uint32_t)':
../node_modules/nan/nan.h:683:12: error: 'Use' is not a member of 'node::Buffer'
     return node::Buffer::Use(v8::Isolate::GetCurrent(), data, size);
            ^
../src/database.cc: In static member function 'static void node_sqlite3::Database::Work_BeginOpen(node_sqlite3::Database::Baton*)':
../src/database.cc:145:9: warning: unused variable 'status' [-Wunused-variable]
     int status = uv_queue_work(uv_default_loop(),
         ^
../src/database.cc: In static member function 'static void node_sqlite3::Database::Work_BeginClose(node_sqlite3::Database::Baton*)':
../src/database.cc:230:9: warning: unused variable 'status' [-Wunused-variable]
     int status = uv_queue_work(uv_default_loop(),
         ^
../src/database.cc: In static member function 'static void node_sqlite3::Database::Work_BeginExec(node_sqlite3::Database::Baton*)':
../src/database.cc:509:9: warning: unused variable 'status' [-Wunused-variable]
     int status = uv_queue_work(uv_default_loop(),
         ^
../src/database.cc: In static member function 'static void node_sqlite3::Database::Work_BeginLoadExtension(node_sqlite3::Database::Baton*)':
../src/database.cc:610:9: warning: unused variable 'status' [-Wunused-variable]
     int status = uv_queue_work(uv_default_loop(),
         ^
make: *** [Release/obj.target/node_sqlite3/src/database.o] Error 1
make: Leaving directory `/kosmtik/node_modules/sqlite3/build'
gyp ERR! build error 
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/kosmtik/node_modules/npm/node_modules/node-gyp/lib/build.js:276:23)
gyp ERR! stack     at emitTwo (events.js:100:13)
gyp ERR! stack     at ChildProcess.emit (events.js:185:7)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:200:12)
gyp ERR! System Linux 3.16.0-48-generic
gyp ERR! command "/usr/bin/nodejs" "/kosmtik/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "build" "--fallback-to-build" "--module=/kosmtik/node_modules/sqlite3/lib/binding/node-v47-linux-x64/node_sqlite3.node" "--module_name=node_sqlite3" "--module_path=/kosmtik/node_modules/sqlite3/lib/binding/node-v47-linux-x64"
gyp ERR! cwd /kosmtik/node_modules/sqlite3
gyp ERR! node -v v5.5.0
gyp ERR! node-gyp -v v3.2.1
gyp ERR! not ok 
node-pre-gyp ERR! build error 
node-pre-gyp ERR! stack Error: Failed to execute '/usr/bin/nodejs /kosmtik/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js build --fallback-to-build --module=/kosmtik/node_modules/sqlite3/lib/binding/node-v47-linux-x64/node_sqlite3.node --module_name=node_sqlite3 --module_path=/kosmtik/node_modules/sqlite3/lib/binding/node-v47-linux-x64' (1)
node-pre-gyp ERR! stack     at ChildProcess.<anonymous> (/kosmtik/node_modules/sqlite3/node_modules/node-pre-gyp/lib/util/compile.js:83:29)
node-pre-gyp ERR! stack     at emitTwo (events.js:100:13)
node-pre-gyp ERR! stack     at ChildProcess.emit (events.js:185:7)
node-pre-gyp ERR! stack     at maybeClose (internal/child_process.js:821:16)
node-pre-gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:211:5)
node-pre-gyp ERR! System Linux 3.16.0-48-generic
node-pre-gyp ERR! command "/usr/bin/nodejs" "/kosmtik/node_modules/sqlite3/node_modules/.bin/node-pre-gyp" "install" "--fallback-to-build"
node-pre-gyp ERR! cwd /kosmtik/node_modules/sqlite3
node-pre-gyp ERR! node -v v5.5.0
node-pre-gyp ERR! node-pre-gyp -v v0.6.9
node-pre-gyp ERR! not ok 
Failed to execute '/usr/bin/nodejs /kosmtik/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js build --fallback-to-build --module=/kosmtik/node_modules/sqlite3/lib/binding/node-v47-linux-x64/node_sqlite3.node --module_name=node_sqlite3 --module_path=/kosmtik/node_modules/sqlite3/lib/binding/node-v47-linux-x64' (1)
npm WARN install:sqlite3@3.0.10 sqlite3@3.0.10 install: `node-pre-gyp install --fallback-to-build`
npm WARN install:sqlite3@3.0.10 Exit status 1
```

To be able to install through npm command line, I've updated the mbtiles dependency version.

I think I need to solve some additional issues.

My main concern in this PR is the fact I was unable to find a way to test with `node index.js plugins --install kosmtik-mbtiles-export` as I do not see how to replace the package with mine using kosmtik installer.
I'm also wondering how to manage install for older version of Node within Kosmtik.
I tried to specified kosmtik plugins version with `node index.js plugins --install kosmtik-mbtiles-export@0.0.5`. Is it the right way?
